### PR TITLE
add null-pointer check on return of getPageList

### DIFF
--- a/src/com/sketchpunk/ocomicreader/lib/ComicRar.java
+++ b/src/com/sketchpunk/ocomicreader/lib/ComicRar.java
@@ -81,7 +81,7 @@ public class ComicRar implements iComicArchive{
 
 	public boolean getLibraryData(String[] outVar){
 		List<String> pgList = getPageList(); //List is already filtered and sorted, this is easier then zip
-		if(pgList.size() > 0){
+		if(pgList != null && !pgList.isEmpty()){
 			outVar[0] = Integer.toString(pgList.size()); //Page Count
 			outVar[1] = pgList.get(0); //Path to Cover Entry
 			return true;


### PR DESCRIPTION
Had an issue with wrong thumbnails showing for a lot of comics, and comics having the series name set to "unknown". 
Was caused by a null-pointer exception on the changed line.
